### PR TITLE
[feat] Create Radio

### DIFF
--- a/src/components/atom/Radio/index.tsx
+++ b/src/components/atom/Radio/index.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { TouchableOpacity, View } from 'react-native';
+
+interface RadioProps {
+  label: string;
+  selected: string;
+  onPress: () => void;
+  radius?: number;
+}
+
+const Radio = ({ label, selected, onPress, radius = 10 }: RadioProps) => {
+  return (
+    <TouchableOpacity onPress={onPress}>
+      <View
+        style={{
+          width: radius,
+          height: radius,
+          borderRadius: radius,
+          borderWidth: 1,
+          alignItems: 'center',
+          justifyContent: 'center',
+          padding: 2,
+        }}
+      >
+        <View
+          style={[
+            {
+              width: radius - 4,
+              height: radius - 4,
+              borderRadius: radius - 4,
+            },
+            selected === label
+              ? { backgroundColor: 'black' }
+              : { backgroundColor: 'transparent' },
+          ]}
+        ></View>
+      </View>
+    </TouchableOpacity>
+  );
+};
+
+export default Radio;

--- a/src/components/atom/index.ts
+++ b/src/components/atom/index.ts
@@ -1,7 +1,6 @@
 import Button from 'src/components/atom/Button';
 import Typography from 'src/components/atom/Typography';
 import TextInput from 'src/components/atom/TextInput';
+import Radio from 'src/components/atom/Radio';
 
-
-export { Button, TextInput, Typography };
-
+export { Button, TextInput, Typography, Radio };

--- a/src/stories/Radio.stories.tsx
+++ b/src/stories/Radio.stories.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+import Radio from 'src/components/atom/Radio';
+
+export default {
+  title: 'Radio/basic',
+  component: Radio,
+} as ComponentMeta<typeof Radio>;
+
+const Template: ComponentStory<typeof Radio> = (args) => <Radio {...args} />;
+
+export const BasicRadio = Template.bind({});
+
+BasicRadio.storyName = 'Basic Radio';
+BasicRadio.args = {
+  label: '테스트',
+  selected: '',
+  onPress: () => {},
+};


### PR DESCRIPTION
1. 커스텀 버튼을 만들 때 쓰는 View + Pressable + Text 에서 아이디어를 얻어서 TouchableOpacity + View + View 로 만들어 보았습니다. 혹시나 더 좋은 의견 있으면 해당 방법도 함께 토의하면 좋을 거 같습니다.
2. Radio input이 보통 어떻게 사용되는지 고민을 하다가 보니, label과 함께 쓰이는 경우가 대부분이었습니다.
<img width="147" alt="image" src="https://user-images.githubusercontent.com/85842907/234728682-88021f3b-6f2a-433e-a270-0d2fbdd45b1d.png">

그래서 다음 예시 코드처럼 사용할 거 같다고 생각하고 만들어 보았습니다.
```
// 사용부
const Component = () => {
  const [state, setState] = useState('');
  const labels = ['2x2','3x3','4x4',]

  const onPressHandler = (label:string):void => {
    setState(label);
  }

  return {
    <View>
      {labels.map((label) => (
        <View key={label}>
          <Text>{label}</Text>
          <Radio label={label} selected={state} onPress={onPressHandler} />
        </View>
      ))}
    </View>
  }
}

// Radio
const Radio = ({ label, selected, onPress, radius = 10 }: RadioProps) => {
  return (
  <TouchableOpacity onPress={onPress.bind(this, label)}> // 이 부분은 적으면서 생각이 나서 피드백 후 코드에 반영하도록 하겠습니다. 
// 이렇게 쓸거면 사용부에서 setState를 그대로 넘기는 게 아니라 label을 인자로 받는 함수를 wrapping해서 onPress로 넘기도록 수정하겠습니다.
  ...
```
