### PR TITLE
110 fix update flexbox

### DIFF
--- a/src/components/atom/Flexbox.tsx
+++ b/src/components/atom/Flexbox.tsx
@@ -34,7 +34,7 @@ const Flexbox = ({
   gap,
   children,
   flexWrap,
-  width = '100%',
+  width = 'auto',
   ...props
 }: FlexboxProps) => {
   return (
@@ -63,7 +63,7 @@ const FlexItem = ({
   flex,
   alignItems,
   justifyContent,
-  width = '100%',
+  width = 'auto',
   ...props
 }: FlexItemProps) => {
   return (


### PR DESCRIPTION
* Flexbox 의 flex-direction 속성 전달 오류로, 기본값이 undefined 로 설정되는 문제로 인해, 스토리북에서 확인하는 UI 와 빌드 이후에 확인하는 UI 가 달랐습니다. flex-direction 이 의도에 맞게 'row'가 기본적으로 적용되도록 수정하였습니다.

* Flexbox, Flexbox.Item 의 width 기본값을 100%로 변경한 이력이 있는데, 실제로는 width 100% 를 더 자주 활용할 것이라 판단했기 때문에 기본값을 변경하였지만, 
  대부분의 컴포넌트가 width: auto 인 것에 의존하여 작업되었고,
  프론트엔드 개발자에게 익숙한, div 에서의 width 기본값도 'auto'이기 때문에, 기본값을 100%로 지정하는 것이 오히려 혼란스러운 부분이 됨을 느꼈습니다. 
  
 떄문에 해당 부분은 다시 롤백하였습니다. 