### PR TITLE
[feat] Create Chatting 기능 - websocket 

### DIFF
--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 
-const useWebSocket = (url: string) => {
+const useWebSocket = () => {
   const [socket, setSocket] = useState<WebSocket>();
 
   const sendMessage = useCallback(
@@ -13,7 +13,7 @@ const useWebSocket = (url: string) => {
   );
 
   useEffect(() => {
-    const webSocket = new WebSocket(url);
+    const webSocket = new WebSocket('ws://example-backend-server-address:3000');
 
     webSocket.onopen = () => {
       console.log('WebSocket opened');
@@ -39,7 +39,7 @@ const useWebSocket = (url: string) => {
     return () => {
       webSocket.close();
     };
-  }, [sendMessage, url]);
+  }, [sendMessage]);
 
   return { sendMessage };
 };

--- a/src/routes/root/chat/ChatDetailScreen.tsx
+++ b/src/routes/root/chat/ChatDetailScreen.tsx
@@ -175,9 +175,7 @@ const ChatDetailScreen = ({ navigation }) => {
 
   const { selectedImages, pickImage } = useExpoImagePicker();
   const { photoUri, openCamera } = useExpoCamera();
-  const { sendMessage } = useWebSocket(
-    'ws://example-backend-server-address:3000'
-  );
+  const { sendMessage } = useWebSocket();
 
   console.log('앨범: ' + selectedImages, ', 카메라: ' + photoUri);
 


### PR DESCRIPTION
# useWebSocket Hook

expo에서 websocekt 통신을 지원하는 패키지가 있는 줄 알았는데 제가 잘못 알았나봅니다...검색하는데 계속 안 나오더라구요.
그래서 그냥 JavaScript에서 지원하는 WebSocket 모듈을 사용해서 useWebSocket 훅을 만들었습니다.

ChatDetailScreen에서 유저가 input에 입력한 chatText state를 sendMessage 함수에 parameter로 넣어주면 
해당 hook의 sendMessage 함수는 socket이 연결 되어있고 message가 있을 때 message를 보내줍니다.

참고한 자료는 아래와 같습니다.

[RN공식문서](https://reactnative.dev/docs/0.70/network#websocket-support) 
[링크1](https://gist.github.com/ozcanzaferayan/ddc542ccab43e34b055ef845819bcbc1)


# 사용자 인증

웹소켓으로 통신할 때, 보통 어떻게 사용자 인증을 하는지 몰라서 찾아봤습니다.
이 부분은 저희가 선우님과 함께 의논해봐야 하겠죠??

1. HTTP 기반의 인증:
WebSocket 연결 이전에 HTTP 요청을 사용하여 사용자를 인증합니다.
사용자는 앱에 로그인하고, 서버로부터 인증 토큰을 받아옵니다.
WebSocket 연결 시에 HTTP 요청 헤더에 해당 토큰을 추가하여 서버에게 사용자 인증을 전달합니다.

2. 쿠키 기반의 인증:
HTTP 요청을 통해 사용자 인증을 수행하고 서버로부터 쿠키를 받아옵니다.
WebSocket 연결 시에 HTTP 요청 헤더에 해당 쿠키를 추가하여 서버에게 사용자 인증을 전달합니다.
주의: React Native에서는 쿠키를 사용하는 데 일부 제약이 있을 수 있습니다.

3. JWT (JSON Web Token) 사용:
사용자가 로그인하면 서버로부터 JWT를 받아옵니다.
WebSocket 연결 시에 HTTP 요청 헤더에 해당 JWT를 추가하여 서버에게 사용자 인증을 전달합니다.

4. Custom 인증 헤더 사용:
WebSocket 연결 시에 서버가 정의한 특정 헤더를 사용하여 사용자 인증을 수행합니다.
사용자는 해당 헤더를 적절히 생성하여 WebSocket 연결 시에 사용합니다.


저희는 expoSecureStore로 token으로 User Authentication을 관리하는데, message 한 번 보낼때마다 사용자 인증을 하게 되는건지?
잘 모르겠습니다.